### PR TITLE
Bug Fix for v2.0.2

### DIFF
--- a/plugins/MoreCustomFields/lib/MoreCustomFields/SelectedAssets.pm
+++ b/plugins/MoreCustomFields/lib/MoreCustomFields/SelectedAssets.pm
@@ -184,10 +184,10 @@ sub asset_insert_param {
     # a custom field with the basename specified. (Because the asset inserter
     # is being overridden we're affecting a widely-used screen.)
     return 1 unless $field_basename
-        && $field_basename =~ /selected_/ # Could be a `selected_[anything]`
         && MT->model('field')->load({
             blog_id  => $param->{blog_id},
             basename => $field_basename,
+            type => { like => 'selected_%' }, # Could be a `selected_[anything]`
         });
 
     my $ctx = $tmpl->context;


### PR DESCRIPTION
Tested More Custom Fields v2.0.2 on a dev server running MT 5.2, but we were unable to successfully add assets to a Selected Images field.  Reversed last change to code (reverting to v2.0.1), which allowed adding assets to work correctly.  Analyzed code change for v2.0.2, discovered an issue with the committed change.
