### PR TITLE
Bugfix in SelectedEntries/Pages when selected entry/page is deleted

### DIFF
--- a/plugins/MoreCustomFields/lib/MoreCustomFields/SelectedEntries.pm
+++ b/plugins/MoreCustomFields/lib/MoreCustomFields/SelectedEntries.pm
@@ -80,6 +80,10 @@ sub tag_selected_entries {
         # it's possible $entryid could be just a space character, which throws
         # an error. So, this check ensures we always have a valid entry ID.
         if ($entryid =~ m/\d+/) {
+            my $entry = MT->model('entry')->load( $entryid );
+            # Check if the entry actually loaded, it might have been deleted
+            # by a user.
+            next unless $entry;            
             # Assign the meta vars
             local $vars->{__first__}   = !$i;
             local $vars->{__last__}    = !defined $entryids[$i + 1];
@@ -88,7 +92,7 @@ sub tag_selected_entries {
             local $vars->{__counter__} = $i + 1;
 
             # Assign the selected entry
-            local $ctx->{__stash}{entry} = MT->model('entry')->load( $entryid );
+            local $ctx->{__stash}{entry} = $entry;
 
             my $out = $builder->build($ctx, $tokens);
             if (!defined $out) {

--- a/plugins/MoreCustomFields/lib/MoreCustomFields/SelectedEntriesOrPages.pm
+++ b/plugins/MoreCustomFields/lib/MoreCustomFields/SelectedEntriesOrPages.pm
@@ -79,7 +79,10 @@ sub tag_selected_content {
         # it's possible $itemid could be just a space character, which throws
         # an error. So, this check ensures we always have a valid item ID.
         if ( $itemid =~ m/\d+/ ) {
-
+            # Make sure the item actually loaded, it might have been deleted by
+            # a user
+            my $item = MT::Entry->load( { id => $itemid, } );
+            next unless $item;
             # Assign the meta vars
             local $vars->{__first__}   = !$i;
             local $vars->{__last__}    = !defined $itemids[ $i + 1 ];
@@ -88,7 +91,7 @@ sub tag_selected_content {
             local $vars->{__counter__} = $i + 1;
 
             # Assign the selected item
-            my $item = MT::Entry->load( { id => $itemid, } );
+
             local $ctx->{__stash}{entry} = $item;
 
             my $out = $builder->build( $ctx, $tokens );

--- a/plugins/MoreCustomFields/lib/MoreCustomFields/SelectedPages.pm
+++ b/plugins/MoreCustomFields/lib/MoreCustomFields/SelectedPages.pm
@@ -79,6 +79,12 @@ sub tag_selected_pages {
         # it's possible $page_id could be just a space character, which throws
         # an error. So, this check ensures we always have a valid page ID.
         if ($page_id =~ m/\d+/) {
+            # Assign the selected page
+            my $page = MT::Page->load( { id => $page_id } );
+            # Check if the page actually loaded, it might have been deleted
+            # by a user.
+            next unless $page;
+            
             # Assign the meta vars
             local $vars->{__first__}   = !$i;
             local $vars->{__last__}    = !defined $page_ids[$i + 1];
@@ -86,8 +92,6 @@ sub tag_selected_pages {
             local $vars->{__even__}    = ($i % 2) == 1;
             local $vars->{__counter__} = $i + 1;
 
-            # Assign the selected page
-            my $page = MT::Page->load( { id => $page_id, } );
             local $ctx->{__stash}{entry} = $page;
 
             my $out = $builder->build($ctx, $tokens);


### PR DESCRIPTION
Sometimes users delete entries or pages that are still present in a selectedentries or selectedpages custom field.  Using the SelectedEntries or SelectedPages loop in that case leads to mysterious errors about being out of Entry or Page context.

These commits add a quick check after loading the pages or entries to make sure they are actually loaded before adding them to the context and looping over them.